### PR TITLE
Fix issue #16 & 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ develop/
 .vscode/
 dist/
 *egg-info/
+.idea/
+venv2/

--- a/facebook_crawler.py
+++ b/facebook_crawler.py
@@ -129,8 +129,8 @@ def __parsing_ProfileComet__(resp):
 
     max_date = max([edge[1] for edge in edge_list])
     max_date = datetime.datetime.fromtimestamp(int(max_date)).strftime('%Y-%m-%d')
-    cursor = edge_list[-1][-2]
-    print('The maximum date of these posts is: {}, keep crawling...'.format(max_date))
+    cursor = edge_list[-1][-3] # DANGEROUS
+    print('The maximum date of these posts is: {}, {}, keep crawling...'.format(max_date, cursor))
     return edge_list, cursor, max_date
 
 def __parsing_CometModern__(resp):
@@ -147,7 +147,7 @@ def __parsing_CometModern__(resp):
     max_date = max([edge[1] for edge in edge_list])
     max_date = datetime.datetime.fromtimestamp(int(max_date)).strftime('%Y-%m-%d')
     print('The maximum date of these posts is: {}, keep crawling...'.format(max_date))
-    cursor = edge_list[-1][-2]
+    cursor = edge_list[-1][-3] # DANGEROUS
     return edge_list, cursor, max_date
 
 def __extract_reactions__(reactions, reaction_type):
@@ -225,11 +225,10 @@ def Crawl_PagePosts(pageurl, until_date='2018-01-01'):
             break
 
         except Exception as e:
-            print('Break Times {}: Something went wrong with this request. Sleep 15 seconds and retry to request new posts.'.format(break_times))
+            print(f'Break Times {break_times}: [{type(e).__name__}] Exceptions happened with this request. Sleep 15 seconds and retry to request new posts.')
             print('REQUEST LOG >>  pageid: {}, docid: {}, cursor: {}'.format(pageid, docid, cursor))
             print('RESPONSE LOG: ', resp.text[:3000])
             break_times += 1
-            print(f"[{type(e).__name__}] ")
             time.sleep(15)
             # Get New cookie ID
             headers = __get_cookieid__(pageurl)

--- a/facebook_crawler.py
+++ b/facebook_crawler.py
@@ -143,9 +143,16 @@ def __extract_reactions__(reactions, reaction_type):
     return 0
 
 
+def find_json_path(json, path, sep="."):
+    path = path.split(sep)
+    for key in json:
+        json = json.get(key)
+    if json:
+        return json
+
 def has_next_page(resp):
     resp = json.loads(resp.text.split('\r\n', -1)[0])
-    has_next_page = resp['data']['node']['timeline_feed_units'].get('page_info').get('has_next_page')
+    has_next_page = find_json_path(resp, 'data.node.timeline_feed_units.page_info.has_next_page')
     return has_next_page
 
 
@@ -184,6 +191,7 @@ def Crawl_PagePosts(pageurl, until_date='2018-01-01'):
             break_times = 0
         except UnboundLocalError:
             print("Reached the last page")
+            break
 
         except Exception as e:
             print('Break Times {}: Something went wrong with this request. Sleep 15 seconds and retry to request new posts.'.format(break_times))

--- a/facebook_crawler.py
+++ b/facebook_crawler.py
@@ -5,6 +5,8 @@ from bs4 import BeautifulSoup
 import datetime
 import time
 import pandas as pd
+from dicttoxml import dicttoxml
+from lxml import etree
 
 def __get_cookieid__(pageurl):
     '''
@@ -88,7 +90,18 @@ def __parsing_edge__(edge):
     cursor = edge['cursor']
     # url
     url = comet_sections_['context_layout']['story']['comet_sections']['actor_photo']['story']['actors'][0]['url']
-    return [name, creation_time, message, postid, pageid, comment_count, reaction_count, share_count, toplevel_comment_count, top_reactions, cursor, url]
+
+    # attachments
+    attachments = get_attachment(comet_sections_)
+
+    return [name, creation_time, message, postid, pageid, comment_count, reaction_count, share_count, toplevel_comment_count, top_reactions, cursor, url, attachments]
+
+
+def get_attachment(comet_sections_):
+    xml_data = dicttoxml(comet_sections_, attr_type=False)
+    tree = etree.fromstring(xml_data)
+    attachments = tree.xpath('//uri/text()')
+    return attachments
 
 def __parsing_ProfileComet__(resp):
     edge_list = []
@@ -208,7 +221,7 @@ def Crawl_PagePosts(pageurl, until_date='2018-01-01'):
                 break
 
     # Join content and requires
-    df = pd.DataFrame(contents, columns = ['NAME', 'TIME', 'MESSAGE', 'POSTID', 'PAGEID', 'COMMENT_COUNT', 'REACTION_COUNT', 'SHARE_COUNT', 'DISPLAYCOMMENTCOUNT', 'REACTIONS', 'CURSOR', 'URL'])
+    df = pd.DataFrame(contents, columns = ['NAME', 'TIME', 'MESSAGE', 'POSTID', 'PAGEID', 'COMMENT_COUNT', 'REACTION_COUNT', 'SHARE_COUNT', 'DISPLAYCOMMENTCOUNT', 'REACTIONS', 'CURSOR', 'URL', 'ATTACHMENTS'])
 
     reaction_type = []
     for reactions in df['REACTIONS']:

--- a/facebook_crawler.py
+++ b/facebook_crawler.py
@@ -143,6 +143,12 @@ def __extract_reactions__(reactions, reaction_type):
     return 0
 
 
+def has_next_page(resp):
+    resp = json.loads(resp.text.split('\r\n', -1)[0])
+    has_next_page = resp['data']['node']['timeline_feed_units'].get('page_info').get('has_next_page')
+    return has_next_page
+
+
 def Crawl_PagePosts(pageurl, until_date='2018-01-01'):
     # init parameters
     contents = [] # post
@@ -166,8 +172,7 @@ def Crawl_PagePosts(pageurl, until_date='2018-01-01'):
             resp = requests.post(url = 'https://www.facebook.com/api/graphql/', 
                                  data=data, 
                                  headers=headers)
-            has_next_page = resp.json()['data']['node']['timeline_feed_units']['page_info']['has_next_page']
-            if not has_next_page:
+            if not has_next_page(resp):
                 raise UnboundLocalError(f"Reached the last page")
             if req_name == 'ProfileCometTimelineFeedRefetchQuery':
                 edge_list, cursor, max_date = __parsing_ProfileComet__(resp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests==2.24.0
 bs4==0.0.1
 pandas==1.2.4         
 numpy==1.20.3
+dicttoxml==1.7.4


### PR DESCRIPTION
## The root cause of #16 is fixed in this PR:
- message could be empty, use .get() to prevent KeyError

## New Feature:
- This crawler is now able to get multimedia attachments in a story.

## New Flow control
- If the crawler reached the last page, break the while loop 

